### PR TITLE
feat: neovim 0.12 readiness

### DIFF
--- a/plugin/template-literal-comments.lua
+++ b/plugin/template-literal-comments.lua
@@ -1,0 +1,1 @@
+require('template-literal-comments').setup()


### PR DESCRIPTION
## Summary
- Add `plugin/template-literal-comments.lua` so the treesitter directive is registered automatically when the plugin is loaded, without requiring an explicit `setup()` call
- Enables compatibility with `vim.pack` and other package managers that don't have config callbacks